### PR TITLE
Correctly get owner

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/chatprint.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/chatprint.lua
@@ -28,9 +28,9 @@ local function ChatPrint(self,ply,t,...)
 				end
 			end
 			if IsValid(ply) and ply:IsPlayer() then
-				print(E2Lib.getOwner(self.entity):Nick().." to "..ply:Nick()..": "..str)
+				print(self.player:Nick().." to "..ply:Nick()..": "..str)
 			else
-				print(E2Lib.getOwner(self.entity):Nick()..": "..str)
+				print(self.player:Nick()..": "..str)
 			end
 		end
 		net.Start("E2-Custom-ChatPrint")


### PR DESCRIPTION
`E2Lib.getOwner` is supposed to be called as `E2Lib.getOwner(self, targetent)`, with self being the e2 context.  
`E2Lib.getOwner(targetent)` only worked due to a bug, when CPPI was present **and** the target entity had ent.player set correctly (as E2s do). This bug will be fixed shortly in wire, so this method will no longer work.

`self.player` is the correct way to get the owner of the current E2.